### PR TITLE
Change library name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ms-squeal
+#Seriate
 =========
 
 A cross platform node module for Microsoft SQL Server based on [node-mssql](https://www.npmjs.org/package/mssql)
@@ -51,7 +51,7 @@ This method returns a `TransactionContext` instance, and allows you to add 1 or 
 
 Here's an example of using a plain context to read a table:
 
-	squeal.getPlainContext( {
+	seriate.getPlainContext( {
 		user: 'username',
 		password: 'pwd',
 		server: '127.0.0.1',
@@ -95,7 +95,7 @@ The `end` method of a `SqlContext` instance takes a callback which receives a `s
 
 Here's an example of using a plain context to read a table, and then use data from that read to determine details about the next step:
 
-	squeal.getPlainContext( {
+	seriate.getPlainContext( {
 		user: 'username',
 		password: 'pwd',
 		server: '127.0.0.1',
@@ -132,7 +132,7 @@ The above example shows both `step` approaches side-by-side.
 ###getTransactionContext(connectionConfig)
 The `getTransactionContext` method returns a `TransactionContext` instance - which for the most part is nearly identical to a `SqlContext` instance - however, a transaction is started as the context begins its work, and you have the option to commit or rollback in the `end` method's callback. For example:
 
-	squeal.getTransactionContext( {
+	seriate.getTransactionContext( {
 		user: 'username',
 		password: 'pwd',
 		server: '127.0.0.1',
@@ -181,7 +181,7 @@ You can see that the main difference between a `SqlContext` and `TransactionCont
 ###executeTransaction(connectionConfig, queryOptions)
 This is a shortcut method to getting a `TransactionContext` instance to execute one step. It returns a promise, and the `result` argument that's normally fed to the `end` method's callback is passed to the success handler of the promise, and any errors are passed to the error handler. For example:
 
-	squeal.executeTransaction( config, {
+	seriate.executeTransaction( config, {
 		procedure: "UpdateCustomer",
 		params: {
 			customerid: {
@@ -210,7 +210,7 @@ This is a shortcut method to getting a `TransactionContext` instance to execute 
 ###execute(connectionConfig, queryOptions)
 This is a shortcut method to getting a `SqlContext` instance to execute one step. It returns a promise, and the `result` argument that's normally fed to the `end` method's callback is passed to the success handler of the promise, and any errors are passed to the error handler. For example:
 
-	squeal.execute( config, {
+	seriate.execute( config, {
 		preparedSql: "select * from someTable where id = @id",
 		params: {
 			id: {

--- a/example/example.js
+++ b/example/example.js
@@ -1,16 +1,12 @@
-var sql = require( 'mssql' );
-var Monologue = require( 'monologue.js' );
-var machina = require( 'machina' )();
-var SqlContext = require( '../src/SqlContext.js' )( sql, Monologue, machina );
-var TransactionContext = require( '../src/TransactionContext.js' )( sql, SqlContext );
-var squeal = require( '../src/index.js' )( sql, SqlContext, TransactionContext );
-
+var sql = require( '../src/index.js' );
+console.log( 'sql', sql);
 var mod = {};
 
-squeal.getTransactionContext( {
+sql.getTransactionContext( {
 	user: 'nodejs',
 	password: 'nodejs',
 	server: '10.0.1.4',
+	// domain: '', // - uncomment to test NTLM
 	database: 'master'
 } )
 	.step( 'readTables', function( execute ) {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-	"name": "ms-squeal",
+	"name": "seriate",
 	"version": "0.3.0",
-	"description": "A cross platform module for Microsoft SQL Server that wraps the mssql module",
+	"description": "A cross platform module for Microsoft SQL Server that wraps node-mssql",
 	"main": "src/index.js",
 	"author": "LeanKit",
+	"homepage": "http://github.com/leankit-labs/seriate",
 	"license": "MIT License - http://opensource.org/licenses/MIT",
 	"contributors": [ {
 		"name": "Scott Walters",
@@ -21,9 +22,9 @@
 		"configya": "~0.0.5",
 		"lodash": "~2.4.1",
 		"machina": "ifandelse/machina.js",
-		"monologue.js": "^0.2.1",
+		"monologue.js": "0.2.1",
 		"mssql": "~1.1.0",
-		"when": "^3.2.3"
+		"when": "3.2.3"
 	},
 	"devDependencies": {
 		"expect.js": "~0.2.0",
@@ -38,7 +39,7 @@
 	},
 	"scripts": {
 		"test": "gulp test",
-		"intspec": "mocha ./spec/integration/squeal.spec.js --reporter spec",
+		"intspec": "mocha ./spec/integration/seriate.spec.js --reporter spec",
 		"example": "node ./example/example.js"
 	}
 }

--- a/spec/integration/seriate.spec.js
+++ b/spec/integration/seriate.spec.js
@@ -1,14 +1,10 @@
 /* global describe,before,it */
 var expect = require( "expect.js" );
 var sinon = require( "sinon" );
+var sql = require( 'mssql' );
 expect = require( "sinon-expect" ).enhance( expect, sinon, "was" );
 
-var Monologue = require( "monologue.js" );
-var machina = require( "machina" )();
-var sql = require( "mssql" );
-var SqlContext = require( "../../src/SqlContext.js" )( sql, Monologue, machina );
-var TransactionContext = require( "../../src/TransactionContext.js" )( sql, SqlContext );
-var squeal = require( "../../src/index.js" )( sql, SqlContext, TransactionContext );
+var seriate = require( "../../src/index.js" );
 var config = require( "./local-config.json" );
 var getRowId = ( function() {
 	var _id = 0;
@@ -17,10 +13,10 @@ var getRowId = ( function() {
 	};
 }() );
 
-describe( "Squeal Integration Tests", function() {
+describe( "Seriate Integration Tests", function() {
 	before( function( done ) {
 		this.timeout( 20000 );
-		squeal
+		seriate
 			.getPlainContext( config )
 			.step( "DropDatabase", {
 				query: "if db_id('tds_node_test') is not null drop database tds_node_test"
@@ -54,7 +50,7 @@ describe( "Squeal Integration Tests", function() {
 			before( function( done ) {
 				id = getRowId();
 				readCheck = function( done ) {
-					squeal.execute( config, {
+					seriate.execute( config, {
 						preparedSql: "select * from tds_node_test..NodeTestTable where i1 = @i1",
 						params: {
 							i1: {
@@ -70,7 +66,7 @@ describe( "Squeal Integration Tests", function() {
 						done();
 					} );
 				};
-				context = squeal
+				context = seriate
 					.getTransactionContext( config )
 					.step( "insert", {
 						preparedSql: "insert into tds_node_test..NodeTestTable (v1, i1) values (@v1, @i1); select SCOPE_IDENTITY() AS NewId;",
@@ -117,7 +113,7 @@ describe( "Squeal Integration Tests", function() {
 			before( function( done ) {
 				id = getRowId();
 				readCheck = function( done ) {
-					squeal.execute( config, {
+					seriate.execute( config, {
 						preparedSql: "select * from tds_node_test..NodeTestTable where i1 = @i1",
 						params: {
 							i1: {
@@ -133,7 +129,7 @@ describe( "Squeal Integration Tests", function() {
 						done();
 					} );
 				};
-				context = squeal
+				context = seriate
 					.getTransactionContext( config )
 					.step( "insert", {
 						preparedSql: "insert into tds_node_test..NodeTestTable (v1, i1) values (@v1, @i1)",
@@ -177,7 +173,7 @@ describe( "Squeal Integration Tests", function() {
 		before( function( done ) {
 			id = getRowId();
 			insertCheck = function( done ) {
-				squeal.execute( config, {
+				seriate.execute( config, {
 					preparedSql: "select * from tds_node_test..NodeTestTable where i1 = @i1",
 					params: {
 						i1: {
@@ -191,7 +187,7 @@ describe( "Squeal Integration Tests", function() {
 				} );
 			};
 			updateCheck = function( done ) {
-				squeal.execute( config, {
+				seriate.execute( config, {
 					preparedSql: "select * from tds_node_test..NodeTestTable where i1 = @i1",
 					params: {
 						i1: {
@@ -205,7 +201,7 @@ describe( "Squeal Integration Tests", function() {
 				} );
 			};
 			updateCmd = function( done ) {
-				squeal.execute( config, {
+				seriate.execute( config, {
 					preparedSql: "update tds_node_test..NodeTestTable set v1 = @v1 where i1 = @i1",
 					params: {
 						i1: {
@@ -223,7 +219,7 @@ describe( "Squeal Integration Tests", function() {
 					updateErr = err;
 				} );
 			};
-			squeal.execute( config, {
+			seriate.execute( config, {
 				preparedSql: "insert into tds_node_test..NodeTestTable (v1, i1) values (@v1, @i1)",
 				params: {
 					i1: {

--- a/spec/unit/SqlContext-Success.spec.js
+++ b/spec/unit/SqlContext-Success.spec.js
@@ -13,7 +13,7 @@ var records = require( './fakeRecordSet.json' );
 var Monologue = require( 'monologue.js' );
 var machina = require( 'machina' )();
 var sql = require( 'mssql' );
-var SqlContext = require( '../../src/SqlContext.js' )( sql, Monologue, machina );
+var SqlContext = require( '../../src/sqlContext.js' )( sql, Monologue, machina );
 
 describe( 'With Successful SqlContext Executions', function() {
 	var reqStub;

--- a/spec/unit/TransactionContext-Success.spec.js
+++ b/spec/unit/TransactionContext-Success.spec.js
@@ -13,8 +13,8 @@ var records = require( './fakeRecordSet.json' );
 var Monologue = require( 'monologue.js' );
 var machina = require( 'machina' )();
 var sql = require( 'mssql' );
-var SqlContext = require( '../../src/SqlContext.js' )( sql, Monologue, machina );
-var TransactionContext = require( '../../src/TransactionContext.js' )( sql, SqlContext );
+var SqlContext = require( '../../src/sqlContext.js' )( sql, Monologue, machina );
+var TransactionContext = require( '../../src/transactionContext.js' )( sql, SqlContext );
 
 describe( 'With Successful TransactionContext Executions', function() {
 	var reqStub;

--- a/src/SqlContext.js
+++ b/src/SqlContext.js
@@ -6,7 +6,7 @@ var Monologue;
 
 function errorHandler( err ) {
 	console.log( "ERR" );
-	console.log( err );
+	console.log( err.stack );
 	this.err = err;
 	this.transition( "Error" );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,42 +1,8 @@
-var when = require( 'when' );
-var sql;
-var TransactionContext;
-var SqlContext;
+var sql = require( 'mssql' );
+var Monologue = require( 'monologue.js' );
+var machina = require( 'machina' )();
+var SqlContext = require( '../src/sqlContext.js' )( sql, Monologue, machina );
+var TransactionContext = require( '../src/transactionContext.js' )( sql, SqlContext );
+var seriate = require( '../src/main.js' )( SqlContext, TransactionContext );
 
-function promisify( context, queryOptions ) {
-	context.step( 'result', queryOptions );
-	return when.promise( function( resolve, reject, notify ) {
-		context
-			.end( resolve )
-			.error( reject )
-			.on( 'data', notify );
-	} );
-}
-
-module.exports = function( mssql, SqlContextCtor, TransactionContextCtor ) {
-	sql = mssql;
-	SqlContext = SqlContextCtor;
-	TransactionContext = TransactionContextCtor;
-	return {
-		getTransactionContext: function( config ) {
-			return new TransactionContext( {
-				connectionCfg: config
-			} );
-		},
-		getPlainContext: function( config ) {
-			return new SqlContext( {
-				connectionCfg: config
-			} );
-		},
-		executeTransaction: function( connCfg, queryOptions ) {
-			return promisify( new TransactionContext( {
-				connectionCfg: connCfg
-			} ), queryOptions );
-		},
-		execute: function( connCfg, queryOptions ) {
-			return promisify( new SqlContext( {
-				connectionCfg: connCfg
-			} ), queryOptions );
-		}
-	};
-};
+module.exports = seriate;

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,40 @@
+var when = require( 'when' );
+var SqlContext;
+var TransactionContext;
+
+function promisify( context, queryOptions ) {
+	context.step( 'result', queryOptions );
+	return when.promise( function( resolve, reject, notify ) {
+		context
+			.end( resolve )
+			.error( reject )
+			.on( 'data', notify );
+	} );
+}
+
+module.exports = function( SqlContextCtor, TransactionContextCtor ) {
+	SqlContext = SqlContextCtor;
+	TransactionContext = TransactionContextCtor;
+	return {
+		getTransactionContext: function( config ) {
+			return new TransactionContext( {
+				connectionCfg: config
+			} );
+		},
+		getPlainContext: function( config ) {
+			return new SqlContext( {
+				connectionCfg: config
+			} );
+		},
+		executeTransaction: function( connCfg, queryOptions ) {
+			return promisify( new TransactionContext( {
+				connectionCfg: connCfg
+			} ), queryOptions );
+		},
+		execute: function( connCfg, queryOptions ) {
+			return promisify( new SqlContext( {
+				connectionCfg: connCfg
+			} ), queryOptions );
+		}
+	};
+};


### PR DESCRIPTION
Change library name to seriate. Simplify how library is required by consuming code. Now you just

``` javascript
var sql = require( 'seriate' );
```

Ta-dow.
