### PR TITLE
Catch unfixable jscs errors in gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,10 @@ gulp.task( "format", [ "jshint" ], function() {
 			configPath: ".jscsrc",
 			fix: true
 		} ) )
+		.on( "error", function( error ) {
+			gutil.log( gutil.colors.red( error.message ) );
+			this.end();
+		} )
 		.pipe( gulpChanged( ".", { hasChanged: gulpChanged.compareSha1Digest } ) )
 		.pipe( gulp.dest( "." ) );
 } );


### PR DESCRIPTION
Properly handle errors when jscs is unable to fix a formatting issue.