### PR TITLE
Added Repository field into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "author": "LeanKit",
   "homepage": "http://github.com/leankit-labs/seriate",
   "license": "MIT License - http://opensource.org/licenses/MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LeanKit-Labs/seriate.git"
+  },
   "contributors": [
     {
       "name": "Scott Walters",


### PR DESCRIPTION
Hey there,

I recently installed your package and everytime I run my project I get the nice warning of: `npm WARN package.json seriate@0.4.2 No repository field.`

To fix this I've added the repository field to the package.json.