### PR TITLE
Always resolve/reject on end/error when calling .then on a SQL context

### DIFF
--- a/spec/behavior/sqlContext.spec.js
+++ b/spec/behavior/sqlContext.spec.js
@@ -267,60 +267,115 @@ describe( "SqlContext", function() {
 	} );
 
 	describe( "when executing a query throws an error", function() {
-		var ctx, error;
-		before( function() {
+		function reqSetup() {
 			setup();
 			reqMock.expects( "query" )
 				.withArgs( "select * from sys.tables" )
 				.callsArgWith( 1, new Error( "faux pas" ), undefined )
 				.once();
 
-			ctx = seriate.getPlainContext();
-			return ctx.step( "read", {
-				query: "select * from sys.tables"
-			} ).then( undefined, function( err ) {
-				error = err;
+			return seriate.getPlainContext();
+		}
+
+		describe( "when passing an error handler", function() {
+			var error;
+			before( function() {
+				var ctx = reqSetup();
+
+				return ctx.step( "read", {
+					query: "select * from sys.tables"
+				} ).then( undefined, function( err ) {
+					error = err;
+				} );
+			} );
+
+			it( "should report error correctly", function() {
+				error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"" );
+			} );
+
+			it( "should call query on request", function() {
+				reqMock.verify();
 			} );
 		} );
 
-		it( "should report error correctly", function() {
-			error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"" );
-		} );
+		describe( "when handling the error from the returned promise", function() {
+			var error;
+			before( function() {
+				var ctx = reqSetup();
 
-		it( "should call query on request", function() {
-			reqMock.verify();
+				return ctx.step( "read", {
+					query: "select * from sys.tables"
+				} ).then().catch( function( err ) {
+					error = err;
+				} );
+			} );
+
+			it( "should report error correctly", function() {
+				error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"" );
+			} );
+
+			it( "should call query on request", function() {
+				reqMock.verify();
+			} );
 		} );
 	} );
 
 	describe( "when executing a proc throws an error", function() {
-		var ctx, error;
-		before( function() {
+		function reqSetup() {
 			setup();
 			reqMock.expects( "execute" )
 				.withArgs( "sp_who2" )
 				.callsArgWith( 1, new Error( "faux pas" ), undefined )
 				.once();
 
-			ctx = seriate.getPlainContext();
-			return ctx.step( "proc", {
-				procedure: "sp_who2"
-			} ).then( undefined, function( err ) {
-				error = err;
+			return seriate.getPlainContext();
+		}
+
+		describe( "when passing an error handler", function() {
+			var error;
+			before( function() {
+				var ctx = reqSetup();
+
+				return ctx.step( "proc", {
+					procedure: "sp_who2"
+				} ).then( undefined, function( err ) {
+					error = err;
+				} );
+			} );
+
+			it( "should report error correctly", function() {
+				error.message.should.equal( "SqlContext Error. Failed on step \"proc\" with: \"faux pas\"" );
+			} );
+
+			it( "should call execute on request", function() {
+				reqMock.verify();
 			} );
 		} );
 
-		it( "should report error correctly", function() {
-			error.message.should.equal( "SqlContext Error. Failed on step \"proc\" with: \"faux pas\"" );
-		} );
+		describe( "when handling the error from the returned promise", function() {
+			var error;
+			before( function() {
+				var ctx = reqSetup();
 
-		it( "should call execute on request", function() {
-			reqMock.verify();
+				return ctx.step( "proc", {
+					procedure: "sp_who2"
+				} ).then().catch( function( err ) {
+					error = err;
+				} );
+			} );
+
+			it( "should report error correctly", function() {
+				error.message.should.equal( "SqlContext Error. Failed on step \"proc\" with: \"faux pas\"" );
+			} );
+
+			it( "should call execute on request", function() {
+				reqMock.verify();
+			} );
 		} );
 	} );
 
 	describe( "when executing prepared throws an error", function() {
-		var ctx, error;
-		before( function() {
+		function prepSetup() {
 			setup();
 			prepMock.expects( "prepare" )
 				.withArgs( "select * from sys.tables where type_desc = @usertable" )
@@ -342,26 +397,61 @@ describe( "SqlContext", function() {
 				.withArgs( "usertable", sql.NVarChar )
 				.once();
 
-			ctx = seriate.getPlainContext();
-			return ctx.step( "prepped", {
-				preparedSql: "select * from sys.tables where type_desc = @usertable",
-				params: {
-					usertable: {
-						type: sql.NVarChar,
-						val: "USER_TABLE"
+			return seriate.getPlainContext();
+		}
+
+		describe( "when passing an error handler", function() {
+			var error;
+			before( function() {
+				var ctx = prepSetup();
+
+				return ctx.step( "prepped", {
+					preparedSql: "select * from sys.tables where type_desc = @usertable",
+					params: {
+						usertable: {
+							type: sql.NVarChar,
+							val: "USER_TABLE"
+						}
 					}
-				}
-			} ).then( undefined, function( err ) {
-				error = err;
+				} ).then( undefined, function( err ) {
+					error = err;
+				} );
+			} );
+
+			it( "should report error correctly", function() {
+				error.message.should.equal( "SqlContext Error. Failed on step \"prepped\" with: \"faux pas\"" );
+			} );
+
+			it( "should execute preparedSql with correct parameters", function() {
+				prepMock.verify();
 			} );
 		} );
 
-		it( "should report error correctly", function() {
-			error.message.should.equal( "SqlContext Error. Failed on step \"prepped\" with: \"faux pas\"" );
-		} );
+		describe( "when handling the error from the returned promise", function() {
+			var error;
+			before( function() {
+				var ctx = prepSetup();
 
-		it( "should execute preparedSql with correct parameters", function() {
-			prepMock.verify();
+				return ctx.step( "prepped", {
+					preparedSql: "select * from sys.tables where type_desc = @usertable",
+					params: {
+						usertable: {
+							type: sql.NVarChar,
+							val: "USER_TABLE"
+						}
+					}
+				} ).then().catch( function( err ) {
+					error = err;
+				} );
+			} );
+
+			it( "should report error correctly", function() {
+				error.message.should.equal( "SqlContext Error. Failed on step \"prepped\" with: \"faux pas\"" );
+			} );
+
+			it( "should execute preparedSql with correct parameters", function() {
+				prepMock.verify();
+			} );
 		} );
 	} );
 

--- a/src/sqlContext.js
+++ b/src/sqlContext.js
@@ -235,12 +235,10 @@ module.exports = function() {
 			function onFailure( error ) {
 				deferred.reject( error );
 			}
-			if ( success ) {
-				this.end( onSuccess );
-			}
-			if ( failure ) {
-				this.error( onFailure );
-			}
+
+			this.end( onSuccess );
+			this.error( onFailure );
+
 			return deferred.promise
 				.then( success, failure );
 		},


### PR DESCRIPTION
Found that when using `sqlContext` and returning the promise created by its `.then` function, it was not possible to handle errors downstream unless you had originally passed in an error handler (or something truthy) for the second arg of `.then`. 

In the case of an error, the promise was left in a pending state, as the `error` state handler that rejects the promise was not setup. I removed the conditions around the end/error handlers in `.then`, as we would likely always want the promise to be either resolved or rejected after execution.

Added test cases for the various SQL context errors to check both passing an error handler and handling downstream.