### PR TITLE
You won't believe how this one easy fix forever improved the way errors are reported.

### DIFF
--- a/spec/behavior/sqlContext.spec.js
+++ b/spec/behavior/sqlContext.spec.js
@@ -296,6 +296,10 @@ describe( "SqlContext", function() {
 			it( "should call query on request", function() {
 				reqMock.verify();
 			} );
+
+			it( "should capture the failing step name on the error", function() {
+				error.step.should.equal( "read" );
+			} );
 		} );
 
 		describe( "when handling the error from the returned promise", function() {
@@ -316,6 +320,10 @@ describe( "SqlContext", function() {
 
 			it( "should call query on request", function() {
 				reqMock.verify();
+			} );
+
+			it( "should capture the failing step name on the error", function() {
+				error.step.should.equal( "read" );
 			} );
 		} );
 	} );
@@ -350,6 +358,10 @@ describe( "SqlContext", function() {
 			it( "should call execute on request", function() {
 				reqMock.verify();
 			} );
+
+			it( "should capture the failing step name on the error", function() {
+				error.step.should.equal( "proc" );
+			} );
 		} );
 
 		describe( "when handling the error from the returned promise", function() {
@@ -370,6 +382,10 @@ describe( "SqlContext", function() {
 
 			it( "should call execute on request", function() {
 				reqMock.verify();
+			} );
+
+			it( "should capture the failing step name on the error", function() {
+				error.step.should.equal( "proc" );
 			} );
 		} );
 	} );
@@ -425,6 +441,10 @@ describe( "SqlContext", function() {
 			it( "should execute preparedSql with correct parameters", function() {
 				prepMock.verify();
 			} );
+
+			it( "should capture the failing step name on the error", function() {
+				error.step.should.equal( "prepped" );
+			} );
 		} );
 
 		describe( "when handling the error from the returned promise", function() {
@@ -451,6 +471,10 @@ describe( "SqlContext", function() {
 
 			it( "should execute preparedSql with correct parameters", function() {
 				prepMock.verify();
+			} );
+
+			it( "should capture the failing step name on the error", function() {
+				error.step.should.equal( "prepped" );
 			} );
 		} );
 	} );

--- a/spec/behavior/transactionContext.spec.js
+++ b/spec/behavior/transactionContext.spec.js
@@ -333,6 +333,10 @@ describe( "TransactionContext", function() {
 		it( "should report the error correctly", function() {
 			error.message.should.eql( "TransactionContext Error. Failed on step \"read\" with: \"so much fail\"" );
 		} );
+
+		it( "should capture the failing step name on the error", function() {
+			error.step.should.equal( "read" );
+		} );
 	} );
 
 	describe( "when calling a stored procedure without parameters throws an error", function() {
@@ -383,6 +387,9 @@ describe( "TransactionContext", function() {
 
 		it( "should report the error correctly", function() {
 			error.message.should.eql( "TransactionContext Error. Failed on step \"proc\" with: \"so much fail\"" );
+		} );
+		it( "should capture the failing step name on the error", function() {
+			error.step.should.equal( "proc" );
 		} );
 	} );
 
@@ -436,6 +443,10 @@ describe( "TransactionContext", function() {
 
 		it( "should report the error correctly", function() {
 			error.message.should.eql( "TransactionContext Error. Failed on step \"proc\" with: \"so much fail\"" );
+		} );
+
+		it( "should capture the failing step name on the error", function() {
+			error.step.should.equal( "proc" );
 		} );
 	} );
 
@@ -509,6 +520,10 @@ describe( "TransactionContext", function() {
 
 		it( "should report the error correctly", function() {
 			error.message.should.eql( "TransactionContext Error. Failed on step \"prepped\" with: \"so much fail\"" );
+		} );
+
+		it( "should capture the failing step name on the error", function() {
+			error.step.should.equal( "prepped" );
 		} );
 	} );
 

--- a/src/sqlContext.js
+++ b/src/sqlContext.js
@@ -189,6 +189,7 @@ module.exports = function() {
 					var message = util.format( "SqlContext Error. Failed on step \"%s\" with: \"%s\"", this.priorState, this.err.message );
 					log.error( message );
 					this.err.message = message;
+					this.err.step = this.priorState;
 					this.emit( "error", this.err );
 				}
 			}

--- a/src/transactionContext.js
+++ b/src/transactionContext.js
@@ -81,6 +81,7 @@ module.exports = function( SqlContext ) {
 				_onEnter: function() {
 					var message = util.format( "TransactionContext Error. Failed on step \"%s\" with: \"%s\"", this.priorState, this.err.message );
 					this.err.message = message;
+					this.err.step = this.priorState;
 
 					if ( this.transaction ) {
 						this.transaction.rollback( function( rollbackErr ) {
@@ -89,9 +90,10 @@ module.exports = function( SqlContext ) {
 														this.priorState,
 														this.err.message,
 														rollbackErr );
+								this.err.message = message;
 							}
 							log.error( message );
-							this.emit( "error", new Error( message ) );
+							this.emit( "error", this.err );
 						}.bind( this ) );
 					} else {
 						log.error( message );


### PR DESCRIPTION
* Added failing step name to error object.
* Prevented rollback errors from swallowing existing error context.