### PR TITLE
Added connectivity events and prevent multiple file reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.5.*
 
+### 0.5.5
+ * Emit connectivity events
+ * Prevent reading sql files multiple times
+
 ### 0.5.4
 Update mssql to 2.3.2
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ A connection configuration provides information on how to connect to the datbase
 }
 ```
 
+### Connectivity Events
+Seriate emits connectivity events from the top level library:
+
+ * connected
+ * closed
+ * failed
+
+Each event includes a `name` property that represents which connection the event is happening on. If the event is failed, an `error` property will have the error that caused the failure.
+
 ## API
 
 Sql type constants are exposed in both Pascal Case and all capitals off of the library. See the listing at the end of this document.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seriate",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A cross platform module for Microsoft SQL Server that wraps node-mssql",
   "main": "src/index.js",
   "author": "LeanKit",
@@ -44,7 +44,7 @@
     "configya": "~0.2.1",
     "lodash": "3.x",
     "machina": "1.x",
-    "monologue.js": "~0.3.1",
+    "monologue.js": "~0.3.3",
     "mssql": "~2.3.2",
     "postal": "^1.0.6",
     "when": "3.x",


### PR DESCRIPTION
Adding connectivity events so that we can easily tie this into autohost-canary and make it clear when a service is unable to connect to sql.

I also removed a problem with how seriate was constantly re-reading the same file every time by caching the contents. I don't know that it will have a major perf impact, but it bugs me. Thanks to @digitalbush for finding it and letting me know.