### PR TITLE
Return additional SQL error information (preceding errors) in the error message

### DIFF
--- a/spec/behavior/sqlContext.spec.js
+++ b/spec/behavior/sqlContext.spec.js
@@ -269,10 +269,16 @@ describe( "SqlContext", function() {
 
 	describe( "when executing a query throws an error", function() {
 		function reqSetup() {
+			var testError = new Error( "faux pas" );
+			testError.precedingErrors = [
+				{ message: "preceding one" },
+				{ message: "preceding two" }
+			];
+
 			setup();
 			reqMock.expects( "query" )
 				.withArgs( "select * from sys.tables" )
-				.callsArgWith( 1, new Error( "faux pas" ), undefined )
+				.callsArgWith( 1, testError, undefined )
 				.once();
 
 			return seriate.getPlainContext();
@@ -291,7 +297,7 @@ describe( "SqlContext", function() {
 			} );
 
 			it( "should report error correctly", function() {
-				error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"" );
+				error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"\n\tPreceding error: preceding one\n\tPreceding error: preceding two" );
 			} );
 
 			it( "should call query on request", function() {
@@ -316,7 +322,7 @@ describe( "SqlContext", function() {
 			} );
 
 			it( "should report error correctly", function() {
-				error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"" );
+				error.message.should.equal( "SqlContext Error. Failed on step \"read\" with: \"faux pas\"\n\tPreceding error: preceding one\n\tPreceding error: preceding two" );
 			} );
 
 			it( "should call query on request", function() {

--- a/spec/behavior/transactionContext.spec.js
+++ b/spec/behavior/transactionContext.spec.js
@@ -287,11 +287,17 @@ describe( "TransactionContext", function() {
 	describe( "when calling a query throws an error", function() {
 		var ctx, error;
 		before( function() {
+			var testError = new Error( "so much fail" );
+			testError.precedingErrors = [
+				{ message: "preceding one" },
+				{ message: "preceding two" }
+			];
+
 			setup();
 			reqMock.expects( "query" )
 				.withArgs( "select * from sys.tables" )
 				.once()
-				.callsArgWith( 1, new Error( "so much fail" ) );
+				.callsArgWith( 1, testError );
 
 			transMock.expects( "begin" )
 				.callsArgWith( 0, null )
@@ -331,7 +337,7 @@ describe( "TransactionContext", function() {
 		} );
 
 		it( "should report the error correctly", function() {
-			error.message.should.eql( "TransactionContext Error. Failed on step \"read\" with: \"so much fail\"" );
+			error.message.should.eql( "TransactionContext Error. Failed on step \"read\" with: \"so much fail\"\n\tPreceding error: preceding one\n\tPreceding error: preceding two" );
 		} );
 
 		it( "should capture the failing step name on the error", function() {

--- a/src/sqlContext.js
+++ b/src/sqlContext.js
@@ -243,7 +243,11 @@ module.exports = function() {
 
 			error: {
 				_onEnter: function() {
-					var message = util.format( "SqlContext Error. Failed on step \"%s\" with: \"%s\"", this.priorState, this.err.message );
+					var precedingErrorMessage = _.map( this.err && this.err.precedingErrors, function( error ) {
+						return "\n\tPreceding error: " + error.message;
+					} ).join( "" );
+
+					var message = util.format( "SqlContext Error. Failed on step \"%s\" with: \"%s\"%s", this.priorState, this.err.message, precedingErrorMessage );
 					log.error( message );
 					this.err.message = message;
 					this.err.step = this.priorState;

--- a/src/transactionContext.js
+++ b/src/transactionContext.js
@@ -1,3 +1,4 @@
+var _ = require( "lodash" );
 var when = require( "when" );
 var util = require( "util" );
 var log = require( "./log" )( "seriate.transaction" );
@@ -79,7 +80,11 @@ module.exports = function( SqlContext ) {
 			},
 			error: {
 				_onEnter: function() {
-					var message = util.format( "TransactionContext Error. Failed on step \"%s\" with: \"%s\"", this.priorState, this.err.message );
+					var precedingErrorMessage = _.map( this.err && this.err.precedingErrors, function( error ) {
+						return "\n\tPreceding error: " + error.message;
+					} ).join( "" );
+
+					var message = util.format( "TransactionContext Error. Failed on step \"%s\" with: \"%s\"%s", this.priorState, this.err.message, precedingErrorMessage );
 					this.err.message = message;
 					this.err.step = this.priorState;
 


### PR DESCRIPTION
Many errors that we receive are logged just as: 

`SqlContext Error. Failed on step "__result__" with: "Statement(s) could not be prepared.`

These changes include messages that are available in the `precedingErrors` property of the error returned. Now the error message would look something like:

```
SqlContext Error. Failed on step "__result__" with: "Statement(s) could not be prepared."
   Preceding error: Invalid column name 'SomeNewColumn'
```
