### PR TITLE
Fix isolation level passed to mssql.

### DIFF
--- a/spec/behavior/transactionContext.spec.js
+++ b/spec/behavior/transactionContext.spec.js
@@ -69,7 +69,7 @@ describe( "TransactionContext", function() {
 				.callsArgWith( 1, null, fakeRecords );
 
 			transMock.expects( "begin" )
-				.withArgs( "serializable" )
+				.withArgs( 0x04 )
 				.callsArgWith( 1, null )
 				.once();
 

--- a/spec/integration/seriate.spec.js
+++ b/spec/integration/seriate.spec.js
@@ -584,4 +584,52 @@ describe( "Seriate Integration Tests", function() {
 			} );
 		} );
 	} );
+
+	describe( "when providing an isolation level", function() {
+		var levels = [ "READ_UNCOMMITTED", "READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", "SNAPSHOT" ];
+
+		levels.forEach( function( level ) {
+			it( "should allow isolation level " + level, function() {
+				var isolationConfig = _.extend( { isolationLevel: sql[ level ] }, config );
+				return sql.getTransactionContext( isolationConfig )
+					.step( "isolation", {
+						query: sql.fromFile( "./sql/isolation" )
+					} )
+					.then( function( result ) {
+						result.transaction
+							.commit()
+							.then( function() {
+								result.sets.isolation[0].level.should.equal( level );
+							} );
+					} );
+			} );
+
+			var stringyLevel = level.toLowerCase();
+			it( "should allow stringy isolation level '" + stringyLevel + "'", function() {
+				var isolationConfig = _.extend( { isolationLevel: stringyLevel }, config );
+				return sql.getTransactionContext( isolationConfig )
+					.step( "isolation", {
+						query: sql.fromFile( "./sql/isolation" )
+					} )
+					.then( function( result ) {
+						result.transaction
+							.commit()
+							.then( function() {
+								result.sets.isolation[0].level.should.equal( level );
+							} );
+					} );
+			} );
+		} );
+
+		it( "should throw error when provided a bad isolation level string", function() {
+			var isolationConfig = _.extend( { isolationLevel: "foo" }, config );
+			return sql.getTransactionContext( isolationConfig )
+					.step( "isolation", {
+						query: sql.fromFile( "./sql/isolation" )
+					} )
+					.then( null, function( err ) {
+						err.message.should.equal( "TransactionContext Error. Failed on step \"startingTransaction\" with: \"Unknown isolation level: \"foo\"\"" );
+					} );
+		} );
+	} );
 } );

--- a/spec/integration/sql/isolation.sql
+++ b/spec/integration/sql/isolation.sql
@@ -1,0 +1,11 @@
+SELECT
+	CASE transaction_isolation_level
+		WHEN 1 THEN 'READ_UNCOMMITTED'
+		WHEN 2 THEN 'READ_COMMITTED'
+		WHEN 3 THEN 'REPEATABLE_READ'
+		WHEN 4 THEN 'SERIALIZABLE'
+		WHEN 5 THEN 'SNAPSHOT'
+		ELSE 'Unknown'
+	END AS level
+FROM sys.dm_exec_sessions
+where session_id = @@SPID

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,10 @@ _.each( sql.TYPES, function( val, key ) {
 	seriate[ key.toUpperCase() ] = sql.TYPES[ key ];
 } );
 
+_.each( sql.ISOLATION_LEVEL, function( val, key ) {
+	seriate[ key ] = sql.ISOLATION_LEVEL[ key ];
+} );
+
 var api = _.assign( seriate, Monologue );
 
 connections.on( "connected", function( info ) {


### PR DESCRIPTION
![](https://lh5.googleusercontent.com/-hQVXGWhL0BI/UeHZGEhWlVI/AAAAAAAAgTg/opJyTnycUlo/w800-h800/bb996df7c7783440d8d879ab4ef8276b_o.gif)
Added isolation level constants to seriate so you can use `{ isolationLevel: sql.REPEATABLE_READ }` when starting a transaction context. Also fixed the stringy versions, so this now works: `{ isolationLevel: "repeatable_read" }`