### PR TITLE
Only create xml when data is present

### DIFF
--- a/spec/behavior/build-table-variable-sql/index.spec.js
+++ b/spec/behavior/build-table-variable-sql/index.spec.js
@@ -1,0 +1,36 @@
+var mssql = require( "mssql" );
+var utils = require( "../../../src/utils" );
+var buildTableVariableSql = require( "../../../src/build-table-variable-sql" );
+
+describe( "buildTableVariableSql", function() {
+	var key, schema, hasData;
+
+	before( function() {
+		key = "parameter";
+		schema = { value: mssql.BIGINT };
+	} );
+
+	describe( "when value has data", function() {
+		before( function() {
+			hasData = true;
+		} );
+
+		it( "should open xml document", function() {
+			var expected = utils.fromFile( "./table-variable-sql-with-xml.sql" );
+			var sql = buildTableVariableSql( key, schema, hasData );
+			sql.should.equal( expected );
+		} );
+	} );
+
+	describe( "when value has no data", function() {
+		before( function() {
+			hasData = false;
+		} );
+
+		it( "should not open xml document", function() {
+			var expected = utils.fromFile( "./table-variable-sql-without-xml.sql" );
+			var sql = buildTableVariableSql( key, schema, hasData );
+			sql.should.equal( expected );
+		} );
+	} );
+} );

--- a/spec/behavior/build-table-variable-sql/table-variable-sql-with-xml.sql
+++ b/spec/behavior/build-table-variable-sql/table-variable-sql-with-xml.sql
@@ -1,0 +1,13 @@
+DECLARE @parameter table (
+  [value] bigint
+)
+
+  DECLARE @parameterIdoc int
+  EXEC sp_xml_preparedocument @parameterIdoc OUTPUT, @parameterXml
+  INSERT @parameter SELECT [value]
+  FROM OPENXML(@parameterIdoc, '//row', 1) WITH (
+    [value] bigint
+  );
+  EXEC sp_xml_removedocument @parameterIdoc;
+
+

--- a/spec/behavior/build-table-variable-sql/table-variable-sql-without-xml.sql
+++ b/spec/behavior/build-table-variable-sql/table-variable-sql-without-xml.sql
@@ -1,0 +1,5 @@
+DECLARE @parameter table (
+  [value] bigint
+)
+
+

--- a/src/build-table-variable-sql.js
+++ b/src/build-table-variable-sql.js
@@ -1,0 +1,16 @@
+var _ = require( "lodash" );
+var declare = require( "mssql/lib/datatypes" ).declare;
+var utils = require( "./utils" );
+
+module.exports = function buildTableVariableSql( key, schema, hasData ) {
+	return _.template( utils.fromFile( "./sql/buildTableVar.sql.template" ) )( {
+		name: key,
+		schema: _.mapValues( schema, function( typeDef ) {
+			if ( _.isFunction( typeDef ) ) {
+				typeDef = typeDef();
+			}
+			return declare( typeDef.type, typeDef );
+		} ),
+		hasData: hasData
+	} ) + "\n";
+};

--- a/src/sql/buildTableVar.sql.template
+++ b/src/sql/buildTableVar.sql.template
@@ -3,14 +3,16 @@ DECLARE @<%= name %> table (
       return "[" + column + "] " + sqlType;
   } ).join( ", " ) %>
 )
-DECLARE @<%= name %>Idoc int
-EXEC sp_xml_preparedocument @<%= name %>Idoc OUTPUT, @<%= name %>Xml
-INSERT @<%= name %> SELECT <%= Object.keys( schema )
-  .map( function( column ) { return "[" + column + "]"; } )
-  .join(", ") %>
-FROM OPENXML(@<%= name %>Idoc, '//row', 1) WITH (
-  <%= _.map( schema, function( sqlType, column ) {
-      return "[" + column + "] " + sqlType;
-  } ).join( ", " ) %>
-);
-EXEC sp_xml_removedocument @<%= name %>Idoc;
+<% if ( hasData ) { %>
+  DECLARE @<%= name %>Idoc int
+  EXEC sp_xml_preparedocument @<%= name %>Idoc OUTPUT, @<%= name %>Xml
+  INSERT @<%= name %> SELECT <%= Object.keys( schema )
+    .map( function( column ) { return "[" + column + "]"; } )
+    .join(", ") %>
+  FROM OPENXML(@<%= name %>Idoc, '//row', 1) WITH (
+    <%= _.map( schema, function( sqlType, column ) {
+        return "[" + column + "] " + sqlType;
+    } ).join( ", " ) %>
+  );
+  EXEC sp_xml_removedocument @<%= name %>Idoc;
+<% } %>

--- a/src/sqlContext.js
+++ b/src/sqlContext.js
@@ -43,7 +43,7 @@ function errorHandler( err ) {
 	this.transition( "error" );
 }
 
-function buildTableVariableSql( key, schema ) {
+function buildTableVariableSql( key, schema, hasData ) {
 	return _.template( utils.fromFile( "./sql/buildTableVar.sql.template" ) )( {
 		name: key,
 		schema: _.mapValues( schema, function( typeDef ) {
@@ -51,7 +51,8 @@ function buildTableVariableSql( key, schema ) {
 				typeDef = typeDef();
 			}
 			return declare( typeDef.type, typeDef );
-		} )
+		} ),
+		hasData: hasData
 	} ) + "\n";
 }
 
@@ -98,7 +99,7 @@ function createParameter( val, key ) {
 			key: key + "Xml",
 			type: sql.NVarChar,
 			value: toXml( val.val, val.asTable ),
-			sqlPrefix: buildTableVariableSql( key, val.asTable )
+			sqlPrefix: buildTableVariableSql( key, val.asTable, !!val.val.length )
 		};
 	}
 	return {

--- a/src/sqlContext.js
+++ b/src/sqlContext.js
@@ -2,9 +2,7 @@ var _ = require( "lodash" );
 var when = require( "when" );
 var lift = require( "when/node" ).lift;
 var sql = require( "mssql" );
-var declare = require( "mssql/lib/datatypes" ).declare;
 var util = require( "util" );
-var utils = require( "./utils" );
 var log = require( "./log" )( "seriate.sql" );
 var Monologue = require( "monologue.js" );
 var machina = require( "machina" );
@@ -12,6 +10,7 @@ var xmldom = require( "xmldom" );
 var domImplementation = new xmldom.DOMImplementation();
 var xmlSerializer = new xmldom.XMLSerializer();
 var Readable = require( "stream" ).Readable;
+var buildTableVariableSql = require( "./build-table-variable-sql" );
 
 util.inherits( DataResultStream, Readable );
 
@@ -41,19 +40,6 @@ DataResultStream.prototype._read = _.noop;
 function errorHandler( err ) {
 	this.err = err;
 	this.transition( "error" );
-}
-
-function buildTableVariableSql( key, schema, hasData ) {
-	return _.template( utils.fromFile( "./sql/buildTableVar.sql.template" ) )( {
-		name: key,
-		schema: _.mapValues( schema, function( typeDef ) {
-			if ( _.isFunction( typeDef ) ) {
-				typeDef = typeDef();
-			}
-			return declare( typeDef.type, typeDef );
-		} ),
-		hasData: hasData
-	} ) + "\n";
 }
 
 function toXml( values, schema ) {


### PR DESCRIPTION
When using an `asTable` parameter, if the value passed in is an empty array, there is no need to bother with an xml document at all. Xml documents are expensive, so we skip it.