### PR TITLE
Added integration tests for Tedious patch

### DIFF
--- a/spec/behavior/tedious-patch.spec.js
+++ b/spec/behavior/tedious-patch.spec.js
@@ -24,7 +24,7 @@ describe( "Tedious makeRequest patch", function() {
 		Connection.prototype.newBulkLoad = existingNewBulkLoad;
 		Connection.prototype.execBulkLoad = existingExecBulkLoad;
 
-		proxyquire( "../src/index", {
+		proxyquire( "../src/tedious-patch", {
 			tedious: {
 				Connection: Connection
 			}
@@ -280,6 +280,28 @@ describe( "Tedious makeRequest patch", function() {
 				.and.calledWith( "ARGS" );
 
 			result.should.equal( "EXECBULK" );
+		} );
+	} );
+
+	describe( "When getting executed twice", function() {
+		var currentMakeRequest, currentNewBulkLoad, currentExecBulkLoad;
+
+		beforeEach( function() {
+			currentMakeRequest = Connection.prototype.makeRequest;
+			currentNewBulkLoad = Connection.prototype.newBulkLoad;
+			currentExecBulkLoad = Connection.prototype.execBulkLoad;
+
+			proxyquire( "../src/tedious-patch", {
+				tedious: {
+					Connection: Connection
+				}
+			} );
+		} );
+
+		it( "should not re-apply the patches", function() {
+			Connection.prototype.makeRequest.should.equal( currentMakeRequest );
+			Connection.prototype.newBulkLoad.should.equal( currentNewBulkLoad );
+			Connection.prototype.execBulkLoad.should.equal( currentExecBulkLoad );
 		} );
 	} );
 } );

--- a/spec/integration/tedious-patch.spec.js
+++ b/spec/integration/tedious-patch.spec.js
@@ -1,0 +1,201 @@
+require( "../setup" );
+var localConfig = require( "./local-config.json" );
+
+describe( "Seriate Integration Tests - Tedious connection reset patch", function() {
+	var config, sql;
+
+	beforeEach( function() {
+		config = Object.assign( {}, localConfig, {
+			pool: {
+				min: 1,
+				max: 1
+			}
+		} );
+
+		sql = proxyquire( "../src/index", {} );
+	} );
+
+	afterEach( function() {
+	} );
+
+	var deleteStep = {
+		query: "DELETE FROM NodeTestTable;"
+	};
+
+	var insertStep = {
+		query: "INSERT INTO NodeTestTable (v1, i1) VALUES ('a', 1);"
+	};
+
+	var selectStep = {
+		query: "SELECT * FROM NodeTestTable"
+	};
+
+	var variableStep = {
+		query: "SELECT @@ROWCOUNT as rows, @@IDENTITY as id"
+	};
+
+	describe( "when using plain context", function() {
+		it( "should reset between steps", function() {
+			return sql.getPlainContext( config )
+				.step( "setup", deleteStep )
+				.step( "insert", insertStep )
+				.step( "select", selectStep )
+				.step( "variables", variableStep )
+				.then( function( result ) {
+					result.variables[ 0 ].should.eql( {
+						rows: 0,
+						id: null
+					} );
+				} );
+		} );
+	} );
+
+	describe( "when using transaction context, reset is run before, but not during transaction", function() {
+		it( "should reset between steps", function() {
+			return sql.getPlainContext( config )
+				.step( "setup", deleteStep )
+				.step( "insert", insertStep )
+				.step( "select", selectStep )
+				.then( function() {
+					return sql.getTransactionContext( config )
+						.step( "variables-before", variableStep )
+						.step( "insert", insertStep )
+						.step( "select", selectStep )
+						.step( "variables-after", variableStep )
+						.then( function( result ) {
+							return result.transaction.commit().then( function() {
+								var recordLength = result.sets.select.length;
+								var lastInsertedId = +result.sets.select[ recordLength - 1 ].bi1;
+
+								// ensure that it was cleared before the transaction
+								result.sets[ "variables-before" ][ 0 ].should.eql( {
+									rows: 0,
+									id: null
+								} );
+
+								// ensure that it was not cleared in transaction
+								result.sets[ "variables-after" ][ 0 ].should.eql( {
+									rows: recordLength,
+									id: lastInsertedId
+								} );
+							} );
+						} );
+				} );
+		} );
+	} );
+
+	describe( "when using prepared SQL", function() {
+		var result;
+
+		beforeEach( function() {
+			return sql.getPlainContext( config )
+				.step( "setup", deleteStep )
+				.step( "insert", insertStep )
+				.step( "select", {
+					preparedSql: selectStep.query
+				} )
+				.step( "variables", variableStep )
+				.then( function( data ) {
+					result = data;
+				} );
+		} );
+
+		it( "should return the prepared SQL result correctly", function() {
+			result.select.should.have.lengthOf( 1 );
+			result.select[ 0 ].v1.should.equal( "a" );
+			result.select[ 0 ].i1.should.equal( 1 );
+		} );
+
+		it( "should reset between steps (and not error from resetting between prepare call and the actual query)", function() {
+			result.variables[ 0 ].should.eql( {
+				rows: 0,
+				id: null
+			} );
+		} );
+	} );
+
+	describe( "when using stored procedure", function() {
+		var result;
+
+		beforeEach( function() {
+			return sql.getPlainContext( config )
+				.step( "setup", deleteStep )
+				.step( "insert", insertStep )
+				.step( "sp", {
+					procedure: "NodeTestMultipleProc",
+					params: {
+						i1: {
+							type: sql.Int,
+							val: 1
+						}
+					}
+				} )
+				.step( "variables", variableStep )
+				.then( function( data ) {
+					result = data;
+				} );
+		} );
+
+		it( "should execute the stored procedure correctly", function() {
+			var procResult = result.sp[ 0 ];
+			procResult[ 0 ].should.have.lengthOf( 1 );
+			procResult[ 0 ][ 0 ].i1.should.equal( 1 );
+			procResult[ 1 ][ 0 ].totalRows.should.equal( 1 );
+		} );
+
+		it( "should reset between steps", function() {
+			result.variables[ 0 ].should.eql( {
+				rows: 0,
+				id: null
+			} );
+		} );
+	} );
+
+	describe( "when bulk loading", function() {
+		var result;
+
+		beforeEach( function() {
+			return sql.getPlainContext( config )
+				.step( "setup", deleteStep )
+				.step( "bulk-load", {
+					bulkLoadTable: {
+						name: "NodeTestTable",
+						columns: {
+							bi1: { type: sql.BIGINT, nullable: false },
+							v1: { type: sql.VARCHAR( 255 ) },
+							i1: { type: sql.INT },
+							d1: { type: sql.DATETIME }
+						},
+						rows: [ {
+							bi1: "123",
+							v1: "Marvin",
+							i1: 234,
+							d1: new Date( 2017, 1, 2, 3, 4, 5 )
+						} ]
+					}
+				} )
+				.step( "select", selectStep )
+				.step( "variables", variableStep )
+				.then( function( data ) {
+					result = data;
+				} );
+		} );
+
+		it( "should successfully execute the bulk load", function() {
+			result.select.should.have.lengthOf( 1 );
+			result.select[ 0 ].should.eql( {
+				bi1: "123",
+				v1: "Marvin",
+				i1: 234,
+				d1: new Date( 2017, 1, 2, 3, 4, 5 )
+			} );
+		} );
+
+		it( "should reset between steps", function() {
+			result.variables[ 0 ].should.eql( {
+				rows: 0,
+				id: null
+			} );
+		} );
+	} );
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -6,56 +6,7 @@ var connections = require( "./connections" );
 var SqlContext = require( "./sqlContext" )();
 var TransactionContext = require( "./transactionContext" )( SqlContext );
 var utils = require( "./utils" );
-var tedious = require( "tedious" );
-
-// I've seen things you people wouldn't believe
-// WHAT DO YOU MEAN BY 'YOU PEOPLE'?!
-/*
-	No really, what's the deal here?
-	Well - it seems that tedious + mssql do not reset connections for us.
-	So we made them. (really, mssql would ideally be doing this when verifying or
-	in an acquire hook before handing connection to a consumer.) Instead, we've
-	patched tedious (and we're not crazy about this) to:
-		* reset before transactions & prepared SQL (but it will wait until the transaction is done or until after
-		  the prepared SQL is unprepared.)
-		* reset before any batch that's not a transaction or prepared SQL
-
-	The `inTransaction` and `resetConnectionOnNextRequest` values are internal to tedious,
-	and we added `isInPreparedSqlQuery` as part of the patch below.
-*/
-var existing = tedious.Connection.prototype.makeRequest;
-tedious.Connection.prototype.makeRequest = function( request, packetType, payload ) {
-	if ( this.inTransaction || this.isInPreparedSqlQuery ||
-		this.isInBulkLoadOperation || this.resetConnectionOnNextRequest ) {
-		if ( request.sqlTextOrProcedure === "sp_unprepare" ) {
-			this.isInPreparedSqlQuery = false;
-		}
-		return existing.call( this, request, packetType, payload );
-	} else {
-		return this.reset( function() {
-			if ( request.sqlTextOrProcedure === "sp_prepare" ) {
-				this.isInPreparedSqlQuery = true;
-			}
-			return existing.call( this, request, packetType, payload );
-		}.bind( this ) );
-	}
-};
-
-var origNewBulkLoad = tedious.Connection.prototype.newBulkLoad;
-tedious.Connection.prototype.newBulkLoad = function( table, callback ) {
-	var thus = this;
-	var result = origNewBulkLoad.call( this, table, function() {
-		callback.apply( this, arguments );
-		thus.isInBulkLoadOperation = false;
-	} );
-	return result;
-};
-
-var origExecBulkLoad = tedious.Connection.prototype.execBulkLoad;
-tedious.Connection.prototype.execBulkLoad = function() {
-	this.isInBulkLoadOperation = true;
-	return origExecBulkLoad.apply( this, arguments );
-};
+require( "./tedious-patch" );
 
 function promisify( context, queryOptions ) {
 	var name = queryOptions.name || queryOptions.procedure || "__result__";

--- a/src/tedious-patch.js
+++ b/src/tedious-patch.js
@@ -1,0 +1,59 @@
+var tedious = require( "tedious" );
+
+// I've seen things you people wouldn't believe
+// WHAT DO YOU MEAN BY 'YOU PEOPLE'?!
+/*
+	No really, what's the deal here?
+	Well - it seems that tedious + mssql do not reset connections for us.
+	So we made them. (really, mssql would ideally be doing this when verifying or
+	in an acquire hook before handing connection to a consumer.) Instead, we've
+	patched tedious (and we're not crazy about this) to:
+		* reset before transactions & prepared SQL (but it will wait until the transaction is done or until after
+		  the prepared SQL is unprepared.)
+		* reset before any batch that's not a transaction or prepared SQL
+
+	The `inTransaction` and `resetConnectionOnNextRequest` values are internal to tedious,
+	and we added `isInPreparedSqlQuery` as part of the patch below.
+*/
+if ( !tedious.Connection.prototype.makeRequest.__seriatePatched ) {
+	var existing = tedious.Connection.prototype.makeRequest;
+	tedious.Connection.prototype.makeRequest = function( request, packetType, payload ) {
+		if ( this.inTransaction || this.isInPreparedSqlQuery ||
+			this.isInBulkLoadOperation || this.resetConnectionOnNextRequest ) {
+			if ( request.sqlTextOrProcedure === "sp_unprepare" ) {
+				this.isInPreparedSqlQuery = false;
+			}
+			return existing.call( this, request, packetType, payload );
+		} else {
+			return this.reset( function() {
+				if ( request.sqlTextOrProcedure === "sp_prepare" ) {
+					this.isInPreparedSqlQuery = true;
+				}
+				return existing.call( this, request, packetType, payload );
+			}.bind( this ) );
+		}
+	};
+	tedious.Connection.prototype.makeRequest.__seriatePatched = true;
+}
+
+if ( !tedious.Connection.prototype.newBulkLoad.__seriatePatched ) {
+	var origNewBulkLoad = tedious.Connection.prototype.newBulkLoad;
+	tedious.Connection.prototype.newBulkLoad = function( table, callback ) {
+		var thus = this;
+		var result = origNewBulkLoad.call( this, table, function() {
+			callback.apply( this, arguments );
+			thus.isInBulkLoadOperation = false;
+		} );
+		return result;
+	};
+	tedious.Connection.prototype.newBulkLoad.__seriatePatched = true;
+}
+
+if ( !tedious.Connection.prototype.execBulkLoad.__seriatePatched ) {
+	var origExecBulkLoad = tedious.Connection.prototype.execBulkLoad;
+	tedious.Connection.prototype.execBulkLoad = function() {
+		this.isInBulkLoadOperation = true;
+		return origExecBulkLoad.apply( this, arguments );
+	};
+	tedious.Connection.prototype.execBulkLoad.__seriatePatched = true;
+}


### PR DESCRIPTION
- Added integration tests to cover the Tedious patch that we are applying to ensure that connections are reset. The tests focus on verifying that @@rowcount and @@identity are no longer available after the patch. Feel free to comment out the patch temporarily and see these tests fail.
- Moved the patch to a separate file
- Ensured that the patch is not applied multiple times (which can cause multiple resets and I noticed errors with prepared SQL). This is helpful in the tests that are using `proxyquire` to get an instance of seriate, but also will protect us in the (hopefully rare) scenario where multiple versions of seriate (with this patch) come into play in an application.
